### PR TITLE
Update lead invite

### DIFF
--- a/src/shared/interfaces/user.type.ts
+++ b/src/shared/interfaces/user.type.ts
@@ -4,7 +4,7 @@ export enum UserRole {
   WRITER = 'WRITER',
   MODERATOR = 'MODERATOR',
   USER = 'USER',
-  EVENT_USER = 'EVENT_USER'
+  EVENT_USER = 'EVENT_USER',
 }
 
 export enum RegistrationMethod {
@@ -17,6 +17,7 @@ export enum UserStatus {
   ACTIVE = 'ACTIVE',
   DISABLE = 'DISABLE',
   DEACTIVATED = 'DEACTIVATED',
+  PENDING = 'PENDING',
 }
 
 export enum ApplicationStatus {

--- a/src/shared/schema/index.ts
+++ b/src/shared/schema/index.ts
@@ -2,17 +2,20 @@ import { ConfigService } from '@nestjs/config';
 import { Connection, ConnectOptions, createConnection } from 'mongoose';
 import { DataLog, DataLogSchema } from './data.log.schema';
 import { EventSchema } from './events.schema';
+import { InviteToken, InviteTokenSchema } from './invite-tokens.schema';
 import { User, UserSchema } from './user.schema';
 
 // All Schema Models
 export * from './data.log.schema';
 export * from './events.schema';
+export * from './invite-tokens.schema';
 export * from './user.schema';
 
 const SCHEMA_LIST = [
   { name: User.name, schema: UserSchema, dbPrefix: 'APP' },
   { name: Event.name, schema: EventSchema, dbPrefix: 'APP' },
   { name: DataLog.name, schema: DataLogSchema, dbPrefix: 'LOG' },
+  { name: InviteToken.name, schema: InviteTokenSchema, dbPrefix: 'APP' },
 ];
 
 export const CONNECTION = SCHEMA_LIST.reduce((result, data) => {

--- a/src/shared/schema/invite-tokens.schema.ts
+++ b/src/shared/schema/invite-tokens.schema.ts
@@ -1,0 +1,21 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type TokenDocument = InviteToken & Document;
+
+@Schema({ timestamps: true })
+export class InviteToken {
+  @Prop({ required: true })
+  email: string;
+
+  @Prop({ required: true })
+  token: string;
+
+  @Prop({ required: true })
+  expiresAt: Date;
+
+  @Prop({ required: true })
+  used: boolean;
+}
+
+export const InviteTokenSchema = SchemaFactory.createForClass(InviteToken);

--- a/src/shared/utils/mail-templates/inventors-lead-invite.hbs
+++ b/src/shared/utils/mail-templates/inventors-lead-invite.hbs
@@ -1,9 +1,15 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
+<html lang='en'>
+  <head>
     <title>Lead Application</title>
-</head>
-<body>
-    <p>Hello {{firstName}}, your application for {{positon}} has been received</p>
-</body>
+  </head>
+  <body>
+    <p>Hello!
+      <br />
+      You have been invited to be a lead on Inventors. Please click the link to
+      change your password and update your details
+      {{link}}
+      <br />
+      Please use 'Inventors1234' to login
+    </p>
+  </body>
 </html>

--- a/src/users/dto/lead-invite-dto.ts
+++ b/src/users/dto/lead-invite-dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDefined, IsEmail, IsNotEmpty } from 'class-validator';
+
+export class createLeadDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsDefined()
+  @IsEmail()
+  email: string;
+}

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -88,4 +88,9 @@ export class UpdateUserDto {
   @IsOptional()
   @IsString()
   userId: string;
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  status?: string;
 }

--- a/src/users/users.admin.controller.ts
+++ b/src/users/users.admin.controller.ts
@@ -1,36 +1,37 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  UseGuards,
-  Request,
-  Param,
+  Controller,
   Delete,
-  Put,
-  Patch,
+  Get,
   Inject,
+  Param,
+  Patch,
+  Post,
+  Put,
   Query,
+  Request,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
+  ApiOperation,
   ApiParam,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
-import { UsersService } from './users.service';
-import { User, UserDocument } from 'src/shared/schema';
 import { Model } from 'mongoose';
 import { JwtAdminsGuard } from 'src/shared/auth/guards/jwt.admins.guard';
-import { UserInviteDto } from './dto/user-invite.dto';
-import { ApiReq, userRoles, userStatuses } from 'src/shared/interfaces';
 import { CreateUserDto } from 'src/shared/dtos/create-user.dto';
+import { ApiReq, userRoles, userStatuses } from 'src/shared/interfaces';
+import { User, UserDocument } from 'src/shared/schema';
+import { RejectApplicationDto } from './dto/reject-lead-application.dto';
+import { UpdateUserStatusDto } from './dto/update-user-status.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserAddPhotoDto } from './dto/user-add-photo.dto';
 import { UserChangePasswordDto } from './dto/user-change-password.dto';
-import { RejectApplicationDto } from './dto/reject-lead-application.dto';
-import { UpdateUserStatusDto } from './dto/update-user-status.dto';
+import { UserInviteDto } from './dto/user-invite.dto';
+import { UsersService } from './users.service';
 
 @ApiTags('admins')
 @Controller('admins')
@@ -51,12 +52,21 @@ export class UsersAdminsController {
   @ApiBearerAuth()
   @UseGuards(JwtAdminsGuard)
   @Get('me')
+  @ApiOperation({
+    summary: 'get my info',
+    description: 'returns all the information about the user in json',
+  })
   getUserProfile(@Request() req: ApiReq) {
     return this.usersService.findMe(req);
   }
 
   @ApiBearerAuth()
   @UseGuards(JwtAdminsGuard)
+  @ApiOperation({
+    summary: 'check exisiting email',
+    description:
+      'check if the email is a valid user email that exists on our database',
+  })
   @Get('users/lookup/:email')
   async findByUsername(@Param('email') email: string) {
     const user = await this.usersService.findByEmail(email);
@@ -66,6 +76,11 @@ export class UsersAdminsController {
   @ApiBearerAuth()
   @UseGuards(JwtAdminsGuard)
   @Delete('users/:id')
+  @ApiOperation({
+    summary: 'delete a user',
+    description:
+      'Delete a user from the application and all their data. Note. As of now, data cannot be reocvered',
+  })
   remove(@Param('id') id: string) {
     return this.usersService.remove(id);
   }
@@ -170,8 +185,15 @@ export class UsersAdminsController {
     return this.usersService.requestVerification(req, userId);
   }
 
+  // TODO: since we're using JwT to pass and handle data on each request, why are we passing userId?
+  // also we seem to be reqiring that they pass in the user json data?
+  // @oyedeletemitope;
   @ApiBearerAuth()
   @UseGuards(JwtAdminsGuard)
+  @ApiOperation({
+    summary: 'update user status',
+    description: 'changees the current status of the selected uerId',
+  })
   @Patch('users/:userId/status')
   async updateUserStatus(
     @Request() req: any,
@@ -184,6 +206,10 @@ export class UsersAdminsController {
   @ApiBearerAuth()
   @UseGuards(JwtAdminsGuard)
   @ApiQuery({ name: 'email', description: 'user email' })
+  @ApiOperation({
+    summary: 'get a lead applicaiton',
+    description: 'finds a lead application using email.',
+  })
   @Get('lead/application/:email')
   async getApplicationByEmail(
     @Query('email') email: string,
@@ -193,6 +219,10 @@ export class UsersAdminsController {
 
   // list all lead applications
   @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'list all pending lead applications',
+    description: 'Get reqest searches for all active/pending lead applications',
+  })
   @UseGuards(JwtAdminsGuard)
   @Get('lead/applications')
   async viewApplications(): Promise<UserDocument[]> {
@@ -205,6 +235,11 @@ export class UsersAdminsController {
   @ApiParam({
     name: 'email',
     description: 'Email of the user application',
+  })
+  @ApiOperation({
+    summary: 'approve a lead application',
+    description:
+      'finds a pending lead application using the email query param and apporve that pending applicaton on that account',
   })
   @Patch('lead/:email/approve')
   async approveApplication(@Param('email') email: string): Promise<string> {
@@ -231,6 +266,10 @@ export class UsersAdminsController {
   // generate registration link
   @ApiBearerAuth()
   @UseGuards(JwtAdminsGuard)
+  @ApiOperation({
+    summary: 'send invite to user',
+    description: 'send an invitation email to new leads to register',
+  })
   @Get('inviteLead/:email') // receive the email param
   async generateLink(@Param('email') email: string): Promise<{ link: string }> {
     // generate and return the link

--- a/src/users/users.admin.controller.ts
+++ b/src/users/users.admin.controller.ts
@@ -288,7 +288,13 @@ export class UsersAdminsController {
   })
   @Post('lead/invite')
   async inviteLead(@Body() body: createLeadDto) {
-    return this.usersService.inviteLead(body.email);
+    return await this.usersService.inviteLead(body.email);
+  }
+
+  // validate the invite lead token
+  @Get('lead/invite/accept')
+  async validateToken(@Query('token') token: string) {
+    return await this.usersService.validateToken(token);
   }
 
   // view all leads

--- a/src/users/users.admin.controller.ts
+++ b/src/users/users.admin.controller.ts
@@ -25,6 +25,7 @@ import { JwtAdminsGuard } from 'src/shared/auth/guards/jwt.admins.guard';
 import { CreateUserDto } from 'src/shared/dtos/create-user.dto';
 import { ApiReq, userRoles, userStatuses } from 'src/shared/interfaces';
 import { User, UserDocument } from 'src/shared/schema';
+import { createLeadDto } from './dto/lead-invite-dto';
 import { RejectApplicationDto } from './dto/reject-lead-application.dto';
 import { UpdateUserStatusDto } from './dto/update-user-status.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -263,18 +264,31 @@ export class UsersAdminsController {
     );
   }
 
-  // generate registration link
+  // // generate registration link
+  // @ApiBearerAuth()
+  // @UseGuards(JwtAdminsGuard)
+  // @ApiOperation({
+  //   summary: 'send invite to user',
+  //   description: 'send an invitation email to new leads to register',
+  // })
+  // @Get('inviteLead/:email') // receive the email param
+  // async generateLink(@Param('email') email: string): Promise<{ link: string }> {
+  //   // generate and return the link
+  //   const link = await this.usersService.inviteLead(email);
+  //   return { link };
+  // }
+
+  // invite a lead
   @ApiBearerAuth()
   @UseGuards(JwtAdminsGuard)
   @ApiOperation({
-    summary: 'send invite to user',
-    description: 'send an invitation email to new leads to register',
+    summary: 'send a lead invite to an email',
+    description:
+      'create a temp account with default/no password and send an invitation link to the email provided in the request',
   })
-  @Get('inviteLead/:email') // receive the email param
-  async generateLink(@Param('email') email: string): Promise<{ link: string }> {
-    // generate and return the link
-    const link = await this.usersService.inviteLead(email);
-    return { link };
+  @Post('lead/invite')
+  async inviteLead(@Body() body: createLeadDto) {
+    return this.usersService.inviteLead(body.email);
   }
 
   // view all leads

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -753,19 +753,20 @@ describe('UsersAdminController', () => {
       });
     });
 
-    describe('generateLink', () => {
-      it('should generate registration link for lead', async () => {
-        const email = 'lead@example.com';
-        const expectedLink = 'http://example.com/register/token123';
+    // describe('generateLink', () => {
+    //   it('should generate registration link for lead', async () => {
+    //     const email = 'lead@example.com';
+    //     const expectedLink = 'http://example.com/register/token123';
 
-        jest.spyOn(usersService, 'inviteLead').mockResolvedValue(expectedLink);
+    //     jest.spyOn(usersService, 'inviteLead').mockResolvedValue(expectedLink);
 
-        const result = await adminController.generateLink(email);
+    //     const result = await adminController.generateLink(email);
 
-        expect(result).toEqual({ link: expectedLink });
-        expect(usersService.inviteLead).toHaveBeenCalledWith(email);
-      });
-    });
+    //     expect(result).toEqual({ link: expectedLink });
+    //     expect(usersService.inviteLead).toHaveBeenCalledWith(email);
+    //   });
+    // });
+    // TODO: add test for the update endpoint
 
     describe('getUsersWithLeadRole', () => {
       it('should return all users with lead role', async () => {


### PR DESCRIPTION
The initial endpoint was built wrongly when compared with the flow that Joel listed out. this has been fixed and re-done. It now follows the flow of invite properly
authenticated user sends invite request -> user receives email with link and temp password -> when clicked, the endpoint checks the validity of the token and returns "valid token" and also the email address.

from this point, the frontend are free to redirect the user wherever, and they also have the email for future requests 