### PR TITLE
Fix user management issues and implement notification module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,10 @@
-<p  align="center">
+# Inventor Backend API
 
-<a  href="http://nestjs.com/"  target="blank"><img  src="https://nestjs.com/img/logo-small.svg"  width="200"  alt="Nest Logo" /></a>
-
-</p>
-
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
-
-<p  align="center">A progressive <a  href="http://nodejs.org"  target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-
-<p  align="center">
-
-<a  href="https://www.npmjs.com/~nestjscore"  target="_blank"><img  src="https://img.shields.io/npm/v/@nestjs/core.svg"  alt="NPM Version" /></a>
-
-<a  href="https://www.npmjs.com/~nestjscore"  target="_blank"><img  src="https://img.shields.io/npm/l/@nestjs/core.svg"  alt="Package License" /></a>
-
-<a  href="https://www.npmjs.com/~nestjscore"  target="_blank"><img  src="https://img.shields.io/npm/dm/@nestjs/common.svg"  alt="NPM Downloads" /></a>
-
-<a  href="https://circleci.com/gh/nestjs/nest"  target="_blank"><img  src="https://img.shields.io/circleci/build/github/nestjs/nest/master"  alt="CircleCI" /></a>
-
-<a  href="https://coveralls.io/github/nestjs/nest?branch=master"  target="_blank"><img  src="https://coveralls.io/repos/github/nestjs/nest/badge.svg?branch=master#9"  alt="Coverage" /></a>
-
-<a  href="https://discord.gg/G7Qnnhy"  target="_blank"><img  src="https://img.shields.io/badge/discord-online-brightgreen.svg"  alt="Discord"/></a>
-
-<a  href="https://opencollective.com/nest#backer"  target="_blank"><img  src="https://opencollective.com/nest/backers/badge.svg"  alt="Backers on Open Collective" /></a>
-
-<a  href="https://opencollective.com/nest#sponsor"  target="_blank"><img  src="https://opencollective.com/nest/sponsors/badge.svg"  alt="Sponsors on Open Collective" /></a>
-
-<a  href="https://paypal.me/kamilmysliwiec"  target="_blank"><img  src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg"/></a>
-
-<a  href="https://opencollective.com/nest#sponsor"  target="_blank"><img  src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg"  alt="Support us"></a>
-
-<a  href="https://twitter.com/nestframework"  target="_blank"><img  src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow"></a>
-
-</p>
-
-<!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-
-[![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+A progressive Node.js framework for building efficient and scalable server-side applications.
 
 ## Description
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+This repository hosts the backend services for the Inventor platform.
 
 ## Setup the app
 
@@ -255,19 +218,7 @@ $  npm  run  test:cov
 
 ```
 
-## Support
-
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)
-
-- Website - [https://nestjs.com](https://nestjs.com/)
-
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
 ## License
 
-Nest is [MIT licensed](LICENSE).
+This project is licensed under the MIT License.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "typescript": "^5.1.3"
       },
       "engines": {
-        "node": ">=18.12.1"
+        "node": ">=20 <23"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4059,18 +4059,6 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
-    },
-    "node_modules/@types/eslint": {
-      "version": "8.56.9",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.9.tgz",
-      "integrity": "sha512-W4W3KcqzjJ0sHg2vAq9vfml6OhsJ53TcUjUqfzzZf/EChUtwspszj/S0pzMxnfRcO55/iGq47dscXw71Fxc4Zg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { DataLogsModule } from './shared/datalogs';
 import { UsersModule } from './users/users.module';
 import { EventModule } from './events/events.users.module';
 import { PostModule } from './blog/post/post.module';
+import { NotificationsModule } from './notifications/notifications.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { PostModule } from './blog/post/post.module';
     UsersModule,
     EventModule,
     PostModule,
+    NotificationsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/notifications/dtos/create-notification.dto.ts
+++ b/src/notifications/dtos/create-notification.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
+import { UserRole } from 'src/shared/interfaces/user.type';
+
+export class CreateNotificationDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  message: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  link?: string;
+
+  @ApiProperty({ enum: ['USER', 'ROLE', 'ALL'] })
+  @IsNotEmpty()
+  @IsEnum(['USER', 'ROLE', 'ALL'])
+  targetType: 'USER' | 'ROLE' | 'ALL';
+
+  @ApiProperty({ type: [String], required: false })
+  @ValidateIf((o) => o.targetType === 'ROLE')
+  @IsNotEmpty()
+  @IsArray()
+  @IsEnum(UserRole, { each: true })
+  targetRoles?: UserRole[];
+
+  @ApiProperty({ type: [String], required: false })
+  @ValidateIf((o) => o.targetType === 'USER')
+  @IsNotEmpty()
+  @IsArray()
+  @IsString({ each: true })
+  targetUsers?: string[];
+}

--- a/src/notifications/notifications.controller.spec.ts
+++ b/src/notifications/notifications.controller.spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+import { CreateNotificationDto } from './dtos/create-notification.dto';
+import { UserRole } from 'src/shared/interfaces/user.type';
+import { ApiReq } from 'src/shared/interfaces';
+import { Types } from 'mongoose';
+
+describe('NotificationsController', () => {
+  let controller: NotificationsController;
+  let service: NotificationsService;
+
+  const mockNotificationsService = {
+    getUserNotifications: jest.fn(),
+    markAsRead: jest.fn(),
+    createNotification: jest.fn(),
+    getAdminNotifications: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NotificationsController],
+      providers: [
+        {
+          provide: NotificationsService,
+          useValue: mockNotificationsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<NotificationsController>(NotificationsController);
+    service = module.get<NotificationsService>(NotificationsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getUserNotifications', () => {
+    it('should return user notifications', async () => {
+      const mockReq = {
+        user: {
+          _id: new Types.ObjectId(),
+          role: [UserRole.USER],
+        },
+      } as unknown as ApiReq;
+
+      const mockResult = [
+        {
+          id: 'notif-1',
+          message: 'Hello',
+          link: 'https://example.com',
+          targetType: 'ALL',
+          createdAt: new Date(),
+          isRead: false,
+        },
+      ];
+
+      mockNotificationsService.getUserNotifications.mockResolvedValue(mockResult);
+
+      const result = await controller.getUserNotifications(mockReq);
+
+      expect(result).toEqual(mockResult);
+      expect(service.getUserNotifications).toHaveBeenCalledWith(
+        mockReq.user._id.toString(),
+        mockReq.user.role,
+      );
+    });
+  });
+
+  describe('markAsRead', () => {
+    it('should mark a notification as read', async () => {
+      const mockReq = {
+        user: {
+          _id: new Types.ObjectId(),
+        },
+      } as unknown as ApiReq;
+      const notifId = 'notif-1';
+      const mockResult = { success: true };
+
+      mockNotificationsService.markAsRead.mockResolvedValue(mockResult);
+
+      const result = await controller.markAsRead(mockReq, notifId);
+
+      expect(result).toEqual(mockResult);
+      expect(service.markAsRead).toHaveBeenCalledWith(
+        mockReq.user._id.toString(),
+        notifId,
+      );
+    });
+  });
+
+  describe('createNotification', () => {
+    it('should create a new notification', async () => {
+      const dto: CreateNotificationDto = {
+        message: 'Hello Group',
+        targetType: 'ROLE',
+        targetRoles: [UserRole.LEAD],
+      };
+      const mockResult = { id: 'notif-2', ...dto };
+
+      mockNotificationsService.createNotification.mockResolvedValue(mockResult);
+
+      const result = await controller.createNotification(dto);
+
+      expect(result).toEqual(mockResult);
+      expect(service.createNotification).toHaveBeenCalledWith(dto);
+    });
+  });
+
+  describe('getAdminNotifications', () => {
+    it('should return admin list of notifications', async () => {
+      const mockReq = {
+        query: { page: '1', limit: '10' },
+      } as unknown as ApiReq;
+      const mockResult = {
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+      };
+
+      mockNotificationsService.getAdminNotifications.mockResolvedValue(mockResult);
+
+      const result = await controller.getAdminNotifications(mockReq);
+
+      expect(result).toEqual(mockResult);
+      expect(service.getAdminNotifications).toHaveBeenCalledWith(mockReq);
+    });
+  });
+});

--- a/src/notifications/notifications.controller.ts
+++ b/src/notifications/notifications.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { JwtUsersGuard } from 'src/shared/auth/guards/jwt.users.guard';
+import { JwtAdminsGuard } from 'src/shared/auth/guards/jwt.admins.guard';
+import { ApiReq } from 'src/shared/interfaces';
+import { NotificationsService } from './notifications.service';
+import { CreateNotificationDto } from './dtos/create-notification.dto';
+
+@Controller()
+export class NotificationsController {
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  @ApiBearerAuth()
+  @UseGuards(JwtUsersGuard)
+  @ApiTags('users')
+  @Get('notifications')
+  async getUserNotifications(@Request() req: ApiReq) {
+    const userId = req.user._id.toString();
+    const userRoles = req.user.role || [];
+    return this.notificationsService.getUserNotifications(userId, userRoles);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtUsersGuard)
+  @ApiTags('users')
+  @Patch('notifications/:id/read')
+  async markAsRead(@Request() req: ApiReq, @Param('id') id: string) {
+    const userId = req.user._id.toString();
+    return this.notificationsService.markAsRead(userId, id);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAdminsGuard)
+  @ApiTags('admins')
+  @Post('admins/notifications')
+  async createNotification(@Body() payload: CreateNotificationDto) {
+    return this.notificationsService.createNotification(payload);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAdminsGuard)
+  @ApiTags('admins')
+  @ApiQuery({ name: 'limit', required: false, type: String } as any)
+  @ApiQuery({ name: 'page', required: false, type: String } as any)
+  @Get('admins/notifications')
+  async getAdminNotifications(@Request() req: ApiReq) {
+    return this.notificationsService.getAdminNotifications(req);
+  }
+}

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DBModule } from 'src/shared/schema';
+import { NotificationsService } from './notifications.service';
+import { NotificationsController } from './notifications.controller';
+
+@Module({
+  imports: [DBModule],
+  controllers: [NotificationsController],
+  providers: [NotificationsService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/src/notifications/notifications.service.spec.ts
+++ b/src/notifications/notifications.service.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Types } from 'mongoose';
+import { NotificationsService } from './notifications.service';
+import { Notification } from 'src/shared/schema/notification.schema';
+import { UserRole } from 'src/shared/interfaces/user.type';
+import { CreateNotificationDto } from './dtos/create-notification.dto';
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+  let modelMock: any;
+
+  const mockNotification = {
+    _id: new Types.ObjectId(),
+    message: 'Test Message',
+    link: 'https://test.com',
+    targetType: 'ALL',
+    targetRoles: [],
+    targetUsers: [],
+    readBy: [],
+    createdAt: new Date(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    mockNotification.save.mockReset();
+
+    // Mock Mongoose model methods
+    modelMock = jest.fn().mockImplementation(() => mockNotification);
+    modelMock.find = jest.fn();
+    modelMock.findByIdAndUpdate = jest.fn();
+    modelMock.countDocuments = jest.fn();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationsService,
+        {
+          provide: Notification.name,
+          useValue: modelMock,
+        },
+      ],
+    }).compile();
+
+    service = module.get<NotificationsService>(NotificationsService);
+  });
+
+  describe('createNotification', () => {
+    it('should create and save a new notification', async () => {
+      const dto: CreateNotificationDto = {
+        message: 'Direct Message',
+        targetType: 'USER',
+        targetUsers: [new Types.ObjectId().toString()],
+      };
+
+      const savedDoc = { ...mockNotification, ...dto };
+      mockNotification.save.mockResolvedValue(savedDoc);
+
+      const result = await service.createNotification(dto);
+
+      expect(result).toEqual(savedDoc);
+      expect(mockNotification.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('getUserNotifications', () => {
+    it('should query targeted notifications and append isRead status', async () => {
+      const userId = new Types.ObjectId().toString();
+      const mockDbResult = [
+        {
+          _id: new Types.ObjectId(),
+          message: 'Public Notification',
+          link: '',
+          targetType: 'ALL',
+          readBy: [new Types.ObjectId(userId)],
+          createdAt: new Date(),
+        },
+        {
+          _id: new Types.ObjectId(),
+          message: 'Unread Targeted Notification',
+          link: '',
+          targetType: 'USER',
+          readBy: [],
+          createdAt: new Date(),
+        },
+      ];
+
+      const findMock = {
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue(mockDbResult),
+      };
+      modelMock.find.mockReturnValue(findMock);
+
+      const result = await service.getUserNotifications(userId, [UserRole.USER]);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].isRead).toBe(true);
+      expect(result[1].isRead).toBe(false);
+      expect(modelMock.find).toHaveBeenCalledWith({
+        $or: [
+          { targetType: 'ALL' },
+          { targetType: 'ROLE', targetRoles: { $in: [UserRole.USER] } },
+          { targetType: 'USER', targetUsers: new Types.ObjectId(userId) },
+        ],
+      });
+    });
+  });
+
+  describe('markAsRead', () => {
+    it('should add userId to readBy using $addToSet', async () => {
+      const userId = new Types.ObjectId().toString();
+      const notificationId = new Types.ObjectId().toString();
+
+      const updateMock = {
+        exec: jest.fn().mockResolvedValue({ _id: notificationId }),
+      };
+      modelMock.findByIdAndUpdate.mockReturnValue(updateMock);
+
+      const result = await service.markAsRead(userId, notificationId);
+
+      expect(result).toEqual({ success: true });
+      expect(modelMock.findByIdAndUpdate).toHaveBeenCalledWith(
+        notificationId,
+        { $addToSet: { readBy: new Types.ObjectId(userId) } },
+        { new: true },
+      );
+    });
+  });
+});

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -1,0 +1,106 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Model, Types } from 'mongoose';
+import { Notification, NotificationDocument } from 'src/shared/schema/notification.schema';
+import { CreateNotificationDto } from './dtos/create-notification.dto';
+import { UserRole } from 'src/shared/interfaces/user.type';
+import { ApiReq } from 'src/shared/interfaces';
+
+@Injectable()
+export class NotificationsService {
+  constructor(
+    @Inject(Notification.name)
+    private readonly notificationModel: Model<NotificationDocument>,
+  ) {}
+
+  async createNotification(dto: CreateNotificationDto): Promise<NotificationDocument> {
+    const targetUsers = dto.targetUsers?.map((id) => new Types.ObjectId(id)) || [];
+    const createdNotification = new this.notificationModel({
+      message: dto.message,
+      link: dto.link,
+      targetType: dto.targetType,
+      targetRoles: dto.targetRoles || [],
+      targetUsers: targetUsers,
+      readBy: [],
+    });
+    return createdNotification.save();
+  }
+
+  async getUserNotifications(userId: string, userRoles: UserRole[]) {
+    const userObjectId = new Types.ObjectId(userId);
+
+    const notifications = await this.notificationModel
+      .find({
+        $or: [
+          { targetType: 'ALL' },
+          { targetType: 'ROLE', targetRoles: { $in: userRoles } },
+          { targetType: 'USER', targetUsers: userObjectId },
+        ],
+      })
+      .sort({ createdAt: -1 })
+      .lean()
+      .exec();
+
+    return notifications.map((notif) => {
+      const readByStrings = (notif.readBy || []).map((id) => id.toString());
+      return {
+        id: notif._id.toString(),
+        message: notif.message,
+        link: notif.link,
+        targetType: notif.targetType,
+        createdAt: notif.createdAt,
+        isRead: readByStrings.includes(userId),
+      };
+    });
+  }
+
+  async markAsRead(userId: string, notificationId: string) {
+    const userObjectId = new Types.ObjectId(userId);
+    const updated = await this.notificationModel
+      .findByIdAndUpdate(
+        notificationId,
+        { $addToSet: { readBy: userObjectId } },
+        { new: true },
+      )
+      .exec();
+
+    if (!updated) {
+      throw new NotFoundException('Notification not found');
+    }
+
+    return { success: true };
+  }
+
+  async getAdminNotifications(req: ApiReq) {
+    // Basic administrative listing of all notifications
+    const page = parseInt(req.query.page as string, 10) || 1;
+    const limit = parseInt(req.query.limit as string, 10) || 10;
+    const skip = (page - 1) * limit;
+
+    const [data, total] = await Promise.all([
+      this.notificationModel
+        .find()
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean()
+        .exec(),
+      this.notificationModel.countDocuments().exec(),
+    ]);
+
+    return {
+      data: data.map((notif) => ({
+        id: notif._id.toString(),
+        message: notif.message,
+        link: notif.link,
+        targetType: notif.targetType,
+        targetRoles: notif.targetRoles,
+        targetUsers: notif.targetUsers,
+        createdAt: notif.createdAt,
+        readCount: notif.readBy?.length || 0,
+      })),
+      total,
+      page,
+      limit,
+    };
+  }
+}

--- a/src/shared/datalogs/data.logs.controller.spec.ts
+++ b/src/shared/datalogs/data.logs.controller.spec.ts
@@ -27,4 +27,19 @@ describe('DataLogsController', () => {
       expect(!!dataLogsController).toBe(true);
     });
   });
+
+  describe('remove', () => {
+    it('should call logsService.remove with the provided dataLogId', async () => {
+      const dataLogId = 'some-log-id';
+      const mockResult = { id: dataLogId, message: 'Log deleted' };
+      const removeSpy = jest
+        .spyOn(global.dataLogsService, 'remove')
+        .mockResolvedValue(mockResult as any);
+
+      const result = await dataLogsController.remove(dataLogId);
+
+      expect(result).toEqual(mockResult);
+      expect(removeSpy).toHaveBeenCalledWith(dataLogId);
+    });
+  });
 });

--- a/src/shared/datalogs/data.logs.controller.ts
+++ b/src/shared/datalogs/data.logs.controller.ts
@@ -94,7 +94,7 @@ export class DataLogsController {
   }
 
   @ApiBearerAuth()
-  // @UseGuards(JwtAdminsGuard)
+  @UseGuards(JwtAdminsGuard)
   @ApiTags('admins')
   @Delete('admins/data-logs/:dataLogId')
   remove(@Param('dataLogId') dataLogId: string) {

--- a/src/shared/schema/index.ts
+++ b/src/shared/schema/index.ts
@@ -9,6 +9,7 @@ import { PostSchema, Post } from './post.schema';
 import { DataLog, DataLogSchema } from './data.log.schema';
 import { InviteToken, InviteTokenSchema } from './invite-tokens.schema';
 import { ProfessionalInfo, ProfessionalInfoSchema } from './professional.info.schema';
+import { Notification, NotificationSchema } from './notification.schema';
 
 
 // All Schema Models
@@ -18,8 +19,9 @@ export * from './data.log.schema';
 export * from './user.schema';
 export * from './events.schema';
 export * from './post.schema';
-export * from './invite-tokens.schema'
-export * from './professional.info.schema'
+export * from './invite-tokens.schema';
+export * from './professional.info.schema';
+export * from './notification.schema';
 
 const SCHEMA_LIST = [
   { name: User.name, schema: UserSchema, dbPrefix: 'APP' },
@@ -34,6 +36,7 @@ const SCHEMA_LIST = [
     dbPrefix: 'APP',
   },
   { name: ContactInfo.name, schema: ContactInfoSchema, dbPrefix: 'APP' },
+  { name: Notification.name, schema: NotificationSchema, dbPrefix: 'APP' },
 ];
 
 export const CONNECTION = SCHEMA_LIST.reduce((result, data) => {

--- a/src/shared/schema/notification.schema.ts
+++ b/src/shared/schema/notification.schema.ts
@@ -1,0 +1,41 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { HydratedDocument, Types } from 'mongoose';
+import { UserRole } from '../interfaces/user.type';
+
+export type NotificationDocument = HydratedDocument<Notification>;
+
+@Schema({ timestamps: true })
+export class Notification {
+  @Prop({ required: true })
+  message: string;
+
+  @Prop({ required: false })
+  link: string;
+
+  @Prop({
+    required: true,
+    enum: ['USER', 'ROLE', 'ALL'],
+    default: 'USER',
+  })
+  targetType: 'USER' | 'ROLE' | 'ALL';
+
+  @Prop({
+    type: [String],
+    default: [],
+  })
+  targetRoles: UserRole[];
+
+  @Prop({
+    type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+    default: [],
+  })
+  targetUsers: Types.ObjectId[];
+
+  @Prop({
+    type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+    default: [],
+  })
+  readBy: Types.ObjectId[];
+}
+
+export const NotificationSchema = SchemaFactory.createForClass(Notification);

--- a/src/shared/schema/user.schema.ts
+++ b/src/shared/schema/user.schema.ts
@@ -314,9 +314,9 @@ UserSchema.statics.signUp = async function signUp(
     subject: 'Welcome to Our Developer Community at Inventors!',
     template: getMailTemplate().generalSignUp,
     templateVariables: {
-      firstName: data.basic_info.firstName,
-      lastName: data.basic_info.lastName,
-      phoneNumber: data.basic_info.phone || undefined,
+      firstName: basic_info.firstName,
+      lastName: basic_info.lastName,
+      phoneNumber: basic_info.phone || undefined,
       email: data.email,
     },
   });

--- a/src/shared/utils/query.util.ts
+++ b/src/shared/utils/query.util.ts
@@ -7,6 +7,7 @@ export const buildQuery = (
   defaultQuery: any = null,
   locationQuery = null,
 ): any => {
+  query = { ...query };
   const filters: Array<any> = [];
 
   const regexSearches = (searchFields, value) => {
@@ -28,7 +29,7 @@ export const buildQuery = (
 
   for (const key in query) {
     let searchFields = [];
-    if (!Object.prototype.hasOwnProperty.call(query, key)) continue;
+    if (!query.hasOwnProperty(key)) continue;
 
     let value = query[key] || '';
 

--- a/src/shared/utils/query.util.ts
+++ b/src/shared/utils/query.util.ts
@@ -28,7 +28,7 @@ export const buildQuery = (
 
   for (const key in query) {
     let searchFields = [];
-    if (!query.hasOwnProperty(key)) continue;
+    if (!Object.prototype.hasOwnProperty.call(query, key)) continue;
 
     let value = query[key] || '';
 

--- a/src/users/users.admin.controller.ts
+++ b/src/users/users.admin.controller.ts
@@ -41,7 +41,7 @@ export class UsersAdminsController {
     @Inject(User.name)
     private readonly userModel: Model<UserDocument>,
     private readonly usersService: UsersService,
-  ) {}
+  ) { }
 
   @ApiBearerAuth()
   @UseGuards(JwtAdminsGuard)
@@ -63,8 +63,11 @@ export class UsersAdminsController {
   })
   @Get('users/lookup/:email')
   async findByUsername(@Param('email') email: string) {
-    const user = await this.usersService.findByEmail(email);
-    return !!(user && user.email);
+    const exists = await this.usersService.checkUserExists(email);
+    return {
+      exists,
+      message: exists ? 'User exists' : 'User does not exist',
+    };
   }
 
   @ApiBearerAuth()

--- a/src/users/users.admin.controller.ts
+++ b/src/users/users.admin.controller.ts
@@ -124,7 +124,7 @@ export class UsersAdminsController {
   @UseGuards(JwtAdminsGuard)
   @Post('users')
   async createUser(@Request() req: ApiReq, @Body() payload: CreateUserDto) {
-    return (this.userModel as any).signUp(req, payload);
+    return this.usersService.createUser(req, payload);
   }
 
   @ApiBearerAuth()

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -11,6 +11,7 @@ import { TestModule } from 'src/shared/testkits';
 import { UsersAdminsController } from './users.admin.controller';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
+import { CreateUserDto } from 'src/shared/dtos/create-user.dto';
 // imported to handle the paginated response from findAll
 import {
   BadRequestException,
@@ -126,6 +127,26 @@ describe('UsersAdminController', () => {
 
       expect(result).toEqual(false);
       expect(usersService.findByEmail).toHaveBeenCalledWith('test@example.com');
+    });
+  });
+
+  describe('createUser', () => {
+    it('should call usersService.createUser with req and payload', async () => {
+      const mockReq = { query: {} } as ApiReq;
+      const createDto: CreateUserDto = {
+        email: 'newuser@example.com',
+        password: 'password123',
+        firstName: 'New',
+        lastName: 'User',
+        joinMethod: RegistrationMethod.SIGN_UP,
+      };
+      const mockCreatedUser = createUserMock({ email: createDto.email });
+      jest.spyOn(usersService, 'createUser').mockResolvedValue(mockCreatedUser as any);
+
+      const result = await adminController.createUser(mockReq, createDto);
+
+      expect(result).toEqual(mockCreatedUser);
+      expect(usersService.createUser).toHaveBeenCalledWith(mockReq, createDto);
     });
   });
 
@@ -497,366 +518,366 @@ describe('UsersAdminController', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-      jest
-        .spyOn(usersService, 'addPhoto')
-        .mockRejectedValue(new BadRequestException());
+    jest
+      .spyOn(usersService, 'addPhoto')
+      .mockRejectedValue(new BadRequestException());
 
-      await expect(
-        adminController.addPhoto(mockReq, userId, photoDto),
-      ).rejects.toThrow(BadRequestException);
-    });
+    await expect(
+      adminController.addPhoto(mockReq, userId, photoDto),
+    ).rejects.toThrow(BadRequestException);
+  });
+});
+
+describe('RequestVerificationToken', () => {
+  const userId = new Types.ObjectId().toString();
+  const mockReq = { user: createUserMock() };
+
+  it('should request new verification token', async () => {
+    jest
+      .spyOn(usersService, 'requestVerification')
+      .mockResolvedValue(undefined);
+
+    await adminController.RequestVerificationToken(mockReq, userId);
+
+    expect(usersService.requestVerification).toHaveBeenCalledWith(
+      mockReq,
+      userId,
+    );
   });
 
-  describe('RequestVerificationToken', () => {
-    const userId = new Types.ObjectId().toString();
+  it('should handle verification errors', async () => {
+    jest
+      .spyOn(usersService, 'requestVerification')
+      .mockRejectedValue(new Error('User not found'));
+
+    await expect(
+      adminController.RequestVerificationToken(mockReq, userId),
+    ).rejects.toThrow('User not found');
+  });
+});
+
+describe('updateUser Status', () => {
+  const userId = new Types.ObjectId().toString();
+
+  it('should update user status to active', async () => {
+    const statusDto = { status: UserStatus.ACTIVE };
+    const mockReq = { user: createUserMock() };
+    const expectedResult = createUserMock({ status: UserStatus.ACTIVE });
+
+    jest
+      .spyOn(usersService, 'updateStatus')
+      .mockResolvedValue(expectedResult);
+
+    const result = await adminController.updateUserStatus(
+      mockReq,
+      userId,
+      statusDto,
+    );
+
+    expect(result).toEqual(expectedResult);
+    expect(usersService.updateStatus).toHaveBeenCalledWith(
+      userId,
+      statusDto.status,
+    );
+  });
+
+  it('should throw error when updating to invalid status', async () => {
+    const invalidStatusDto = { status: 'INVALID_STATUS' as UserStatus };
     const mockReq = { user: createUserMock() };
 
-    it('should request new verification token', async () => {
-      jest
-        .spyOn(usersService, 'requestVerification')
-        .mockResolvedValue(undefined);
+    jest
+      .spyOn(usersService, 'updateStatus')
+      .mockRejectedValue(new BadRequestException('Invalid user status'));
 
-      await adminController.RequestVerificationToken(mockReq, userId);
-
-      expect(usersService.requestVerification).toHaveBeenCalledWith(
-        mockReq,
-        userId,
-      );
-    });
-
-    it('should handle verification errors', async () => {
-      jest
-        .spyOn(usersService, 'requestVerification')
-        .mockRejectedValue(new Error('User not found'));
-
-      await expect(
-        adminController.RequestVerificationToken(mockReq, userId),
-      ).rejects.toThrow('User not found');
-    });
+    await expect(
+      adminController.updateUserStatus(mockReq, userId, invalidStatusDto),
+    ).rejects.toThrow(BadRequestException);
   });
 
-  describe('updateUser Status', () => {
-    const userId = new Types.ObjectId().toString();
-
-    it('should update user status to active', async () => {
-      const statusDto = { status: UserStatus.ACTIVE };
-      const mockReq = { user: createUserMock() };
-      const expectedResult = createUserMock({ status: UserStatus.ACTIVE });
-
-      jest
-        .spyOn(usersService, 'updateStatus')
-        .mockResolvedValue(expectedResult);
-
-      const result = await adminController.updateUserStatus(
-        mockReq,
-        userId,
-        statusDto,
-      );
-
-      expect(result).toEqual(expectedResult);
-      expect(usersService.updateStatus).toHaveBeenCalledWith(
-        userId,
-        statusDto.status,
-      );
-    });
-
-    it('should throw error when updating to invalid status', async () => {
-      const invalidStatusDto = { status: 'INVALID_STATUS' as UserStatus };
-      const mockReq = { user: createUserMock() };
-
-      jest
-        .spyOn(usersService, 'updateStatus')
-        .mockRejectedValue(new BadRequestException('Invalid user status'));
-
-      await expect(
-        adminController.updateUserStatus(mockReq, userId, invalidStatusDto),
-      ).rejects.toThrow(BadRequestException);
-    });
-
-    it('should throw error when updating non-existent user', async () => {
-      const statusDto = { status: UserStatus.ACTIVE };
-      const mockReq = { user: createUserMock() };
-      // Mocking the service to throw an error when the user is not found
-      jest
-        .spyOn(usersService, 'updateStatus')
-        .mockRejectedValue(new NotFoundException('User  not found'));
-
-      await expect(
-        adminController.updateUserStatus(mockReq, userId, statusDto),
-      ).rejects.toThrow(NotFoundException);
-    });
-  });
-
-  describe('Lead application endpoints', () => {
-    describe('getApplicationByEmail', () => {
-      it('should find an application by email', async () => {
-        const email = 'lead@example.com';
-        const expectedResult = createUserMock({ email });
-
-        jest
-          .spyOn(usersService, 'viewOneApplication')
-          .mockResolvedValue(expectedResult);
-
-        const result = await adminController.getApplicationByEmail(email);
-
-        expect(result).toEqual(expectedResult);
-        expect(usersService.viewOneApplication).toHaveBeenCalledWith(email);
-      });
-    });
-
-    describe('viewApplications', () => {
-      it('should return all lead applications', async () => {
-        const expectedResults = [
-          createUserMock({ email: 'lead1@example.com' }),
-          createUserMock({ email: 'lead2@example.com' }),
-        ];
-
-        jest
-          .spyOn(usersService, 'viewApplications')
-          .mockResolvedValue(expectedResults);
-
-        const result = await adminController.viewApplications();
-
-        expect(result).toEqual(expectedResults);
-        expect(usersService.viewApplications).toHaveBeenCalled();
-      });
-    });
-
-    describe('approveApplication', () => {
-      it('should approve a lead application', async () => {
-        const email = 'lead@example.com';
-        const expectedResult = 'Application approved successfully';
-
-        jest
-          .spyOn(usersService, 'approveTempApplication')
-          .mockResolvedValue(expectedResult);
-
-        const result = await adminController.approveApplication(email);
-
-        expect(result).toEqual(expectedResult);
-        expect(usersService.approveTempApplication).toHaveBeenCalledWith(email);
-      });
-    });
-
-    describe('reject', () => {
-      it('should reject a lead application with custom message', async () => {
-        const email = 'lead@example.com';
-        const rejectDto = { message: 'Custom rejection message' };
-        const expectedResult = 'Application rejected successfully';
-
-        jest
-          .spyOn(usersService, 'rejectTempApplication')
-          .mockResolvedValue(expectedResult);
-
-        const result = await adminController.reject(email, rejectDto);
-
-        expect(result).toEqual(expectedResult);
-        expect(usersService.rejectTempApplication).toHaveBeenCalledWith(
-          email,
-          rejectDto.message,
-        );
-      });
-
-      it('should reject with default message when no message provided', async () => {
-        const email = 'lead@example.com';
-        const rejectDto = {};
-        const expectedResult = 'Application rejected successfully';
-
-        jest
-          .spyOn(usersService, 'rejectTempApplication')
-          .mockResolvedValue(expectedResult);
-
-        const result = await adminController.reject(email, rejectDto);
-
-        expect(result).toEqual(expectedResult);
-        expect(usersService.rejectTempApplication).toHaveBeenCalledWith(
-          email,
-          'Your application was rejected',
-        );
-      });
-    });
-
-    describe('getUsersWithLeadRole', () => {
-      it('should return all users with lead role', async () => {
-        const expectedResults = [
-          createUserMock({ role: [UserRole.LEAD] }),
-          createUserMock({ role: [UserRole.LEAD] }),
-        ];
-
-        jest
-          .spyOn(usersService, 'getUsersWithLeadRole')
-          .mockResolvedValue(expectedResults);
-
-        const result = await adminController.getUsersWithLeadRole();
-
-        expect(result).toEqual(expectedResults);
-        expect(usersService.getUsersWithLeadRole).toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('Deactivate User Account', () => {
-    const userId = new Types.ObjectId().toString();
-    const deactivateDto = { reason: 'Taking a break' };
+  it('should throw error when updating non-existent user', async () => {
+    const statusDto = { status: UserStatus.ACTIVE };
     const mockReq = { user: createUserMock() };
+    // Mocking the service to throw an error when the user is not found
+    jest
+      .spyOn(usersService, 'updateStatus')
+      .mockRejectedValue(new NotFoundException('User  not found'));
 
-    it('should deactivate a user account', async () => {
-      const expectedResult = createUserMock({ status: UserStatus.DEACTIVATED });
+    await expect(
+      adminController.updateUserStatus(mockReq, userId, statusDto),
+    ).rejects.toThrow(NotFoundException);
+  });
+});
+
+describe('Lead application endpoints', () => {
+  describe('getApplicationByEmail', () => {
+    it('should find an application by email', async () => {
+      const email = 'lead@example.com';
+      const expectedResult = createUserMock({ email });
+
       jest
-        .spyOn(usersService, 'deactivateAccount')
+        .spyOn(usersService, 'viewOneApplication')
         .mockResolvedValue(expectedResult);
 
-      const result = await controller.deactivateAccount(
-        mockReq,
-        userId,
-        deactivateDto,
-      );
+      const result = await adminController.getApplicationByEmail(email);
 
       expect(result).toEqual(expectedResult);
-      expect(usersService.deactivateAccount).toHaveBeenCalledWith(userId);
-    });
-
-    it('should handle deactivation errors', async () => {
-      jest
-        .spyOn(usersService, 'deactivateAccount')
-        .mockRejectedValue(new NotFoundException());
-
-      await expect(
-        controller.deactivateAccount(mockReq, userId, deactivateDto),
-      ).rejects.toThrow(NotFoundException);
+      expect(usersService.viewOneApplication).toHaveBeenCalledWith(email);
     });
   });
 
-  describe('Request Reactivation', () => {
-    const userId = new Types.ObjectId().toString();
-    const reactivationDto = { message: 'Ready to come back' };
+  describe('viewApplications', () => {
+    it('should return all lead applications', async () => {
+      const expectedResults = [
+        createUserMock({ email: 'lead1@example.com' }),
+        createUserMock({ email: 'lead2@example.com' }),
+      ];
 
-    it('should request reactivation of a user account', async () => {
-      const expectedResult = createUserMock({ status: UserStatus.ACTIVE });
       jest
-        .spyOn(usersService, 'requestReactivation')
-        .mockResolvedValue(expectedResult);
+        .spyOn(usersService, 'viewApplications')
+        .mockResolvedValue(expectedResults);
 
-      const result = await controller.requestReactivation(
-        userId,
-        reactivationDto,
-      );
+      const result = await adminController.viewApplications();
 
-      expect(result).toEqual(expectedResult);
-      expect(usersService.requestReactivation).toHaveBeenCalledWith(userId);
-    });
-
-    it('should handle reactivation errors', async () => {
-      jest
-        .spyOn(usersService, 'requestReactivation')
-        .mockRejectedValue(new NotFoundException());
-
-      await expect(
-        controller.requestReactivation(userId, reactivationDto),
-      ).rejects.toThrow(NotFoundException);
+      expect(result).toEqual(expectedResults);
+      expect(usersService.viewApplications).toHaveBeenCalled();
     });
   });
 
-  describe('Lead Registration', () => {
-    const tempLeadDto = {
-      email: 'lead@example.com',
-      leadPosition: 'Senior Developer',
-      firstName: 'John',
-      lastName: 'Doe',
-      createdAt: new Date(),
-    };
+  describe('approveApplication', () => {
+    it('should approve a lead application', async () => {
+      const email = 'lead@example.com';
+      const expectedResult = 'Application approved successfully';
 
-    it('should successfully register a temporary lead', async () => {
-      const expectedResult = 'Application sent';
       jest
-        .spyOn(usersService, 'createTempRegistration')
+        .spyOn(usersService, 'approveTempApplication')
         .mockResolvedValue(expectedResult);
 
-      const result = await controller.createLead(tempLeadDto);
+      const result = await adminController.approveApplication(email);
 
       expect(result).toEqual(expectedResult);
-      expect(usersService.createTempRegistration).toHaveBeenCalledWith(
-        tempLeadDto.email,
-        tempLeadDto.leadPosition,
-      );
-    });
-
-    it('should throw BadRequestException when registration not allowed', async () => {
-      jest
-        .spyOn(usersService, 'createTempRegistration')
-        .mockRejectedValue(new BadRequestException());
-
-      await expect(controller.createLead(tempLeadDto)).rejects.toThrow(
-        BadRequestException,
-      );
+      expect(usersService.approveTempApplication).toHaveBeenCalledWith(email);
     });
   });
 
-  describe('Register New User Form', () => {
-    const encryptedData = 'encryptedString';
-    const userId = new Types.ObjectId().toString();
-    const email = 'user@example.com';
+  describe('reject', () => {
+    it('should reject a lead application with custom message', async () => {
+      const email = 'lead@example.com';
+      const rejectDto = { message: 'Custom rejection message' };
+      const expectedResult = 'Application rejected successfully';
 
-    it('should redirect to create lead page when user exists', async () => {
-      const mockUser = createUserMock({
-        _id: new Types.ObjectId(userId),
+      jest
+        .spyOn(usersService, 'rejectTempApplication')
+        .mockResolvedValue(expectedResult);
+
+      const result = await adminController.reject(email, rejectDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(usersService.rejectTempApplication).toHaveBeenCalledWith(
         email,
-      });
-
-      jest
-        .spyOn(usersService, 'paraseEncryptedParams')
-        .mockReturnValue({ userId, email });
-      jest.spyOn(usersService, 'findById').mockResolvedValue(mockUser);
-
-      const result = await controller.register(encryptedData);
-
-      expect(result).toEqual({ url: `/leads/createLead?email=${email}` });
+        rejectDto.message,
+      );
     });
 
-    it('should handle invalid links', async () => {
-      jest
-        .spyOn(usersService, 'paraseEncryptedParams')
-        .mockImplementation(() => {
-          throw new Error('Decryption failed');
-        });
+    it('should reject with default message when no message provided', async () => {
+      const email = 'lead@example.com';
+      const rejectDto = {};
+      const expectedResult = 'Application rejected successfully';
 
-      await expect(controller.register(encryptedData)).rejects.toThrow(
-        NotFoundException,
+      jest
+        .spyOn(usersService, 'rejectTempApplication')
+        .mockResolvedValue(expectedResult);
+
+      const result = await adminController.reject(email, rejectDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(usersService.rejectTempApplication).toHaveBeenCalledWith(
+        email,
+        'Your application was rejected',
       );
     });
   });
 
-  describe('User Invite Link', () => {
-    const encryptedData = 'encryptedInviteString';
-    const userId = new Types.ObjectId().toString();
-    const email = 'invite@example.com';
-
-    it('should redirect to create lead page when user exists', async () => {
-      const mockUser = createUserMock({
-        _id: new Types.ObjectId(userId),
-        email,
-      });
+  describe('getUsersWithLeadRole', () => {
+    it('should return all users with lead role', async () => {
+      const expectedResults = [
+        createUserMock({ role: [UserRole.LEAD] }),
+        createUserMock({ role: [UserRole.LEAD] }),
+      ];
 
       jest
-        .spyOn(usersService, 'paraseEncryptedParams')
-        .mockReturnValue({ userId, email });
-      jest.spyOn(usersService, 'findById').mockResolvedValue(mockUser);
+        .spyOn(usersService, 'getUsersWithLeadRole')
+        .mockResolvedValue(expectedResults);
 
-      const result = await controller.register(encryptedData);
+      const result = await adminController.getUsersWithLeadRole();
 
-      expect(result).toEqual({ url: `/leads/createLead?email=${email}` });
-    });
-
-    it('should redirect to new user form when userId is missing', async () => {
-      jest
-        .spyOn(usersService, 'paraseEncryptedParams')
-        .mockReturnValue({ userId: '', email });
-
-      const result = await controller.register(encryptedData);
-
-      expect(result).toEqual({
-        url: `/leads/new-user-form?email=${encodeURIComponent(email)}`,
-      });
+      expect(result).toEqual(expectedResults);
+      expect(usersService.getUsersWithLeadRole).toHaveBeenCalled();
     });
   });
+});
+
+describe('Deactivate User Account', () => {
+  const userId = new Types.ObjectId().toString();
+  const deactivateDto = { reason: 'Taking a break' };
+  const mockReq = { user: createUserMock() };
+
+  it('should deactivate a user account', async () => {
+    const expectedResult = createUserMock({ status: UserStatus.DEACTIVATED });
+    jest
+      .spyOn(usersService, 'deactivateAccount')
+      .mockResolvedValue(expectedResult);
+
+    const result = await controller.deactivateAccount(
+      mockReq,
+      userId,
+      deactivateDto,
+    );
+
+    expect(result).toEqual(expectedResult);
+    expect(usersService.deactivateAccount).toHaveBeenCalledWith(userId);
+  });
+
+  it('should handle deactivation errors', async () => {
+    jest
+      .spyOn(usersService, 'deactivateAccount')
+      .mockRejectedValue(new NotFoundException());
+
+    await expect(
+      controller.deactivateAccount(mockReq, userId, deactivateDto),
+    ).rejects.toThrow(NotFoundException);
+  });
+});
+
+describe('Request Reactivation', () => {
+  const userId = new Types.ObjectId().toString();
+  const reactivationDto = { message: 'Ready to come back' };
+
+  it('should request reactivation of a user account', async () => {
+    const expectedResult = createUserMock({ status: UserStatus.ACTIVE });
+    jest
+      .spyOn(usersService, 'requestReactivation')
+      .mockResolvedValue(expectedResult);
+
+    const result = await controller.requestReactivation(
+      userId,
+      reactivationDto,
+    );
+
+    expect(result).toEqual(expectedResult);
+    expect(usersService.requestReactivation).toHaveBeenCalledWith(userId);
+  });
+
+  it('should handle reactivation errors', async () => {
+    jest
+      .spyOn(usersService, 'requestReactivation')
+      .mockRejectedValue(new NotFoundException());
+
+    await expect(
+      controller.requestReactivation(userId, reactivationDto),
+    ).rejects.toThrow(NotFoundException);
+  });
+});
+
+describe('Lead Registration', () => {
+  const tempLeadDto = {
+    email: 'lead@example.com',
+    leadPosition: 'Senior Developer',
+    firstName: 'John',
+    lastName: 'Doe',
+    createdAt: new Date(),
+  };
+
+  it('should successfully register a temporary lead', async () => {
+    const expectedResult = 'Application sent';
+    jest
+      .spyOn(usersService, 'createTempRegistration')
+      .mockResolvedValue(expectedResult);
+
+    const result = await controller.createLead(tempLeadDto);
+
+    expect(result).toEqual(expectedResult);
+    expect(usersService.createTempRegistration).toHaveBeenCalledWith(
+      tempLeadDto.email,
+      tempLeadDto.leadPosition,
+    );
+  });
+
+  it('should throw BadRequestException when registration not allowed', async () => {
+    jest
+      .spyOn(usersService, 'createTempRegistration')
+      .mockRejectedValue(new BadRequestException());
+
+    await expect(controller.createLead(tempLeadDto)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+});
+
+describe('Register New User Form', () => {
+  const encryptedData = 'encryptedString';
+  const userId = new Types.ObjectId().toString();
+  const email = 'user@example.com';
+
+  it('should redirect to create lead page when user exists', async () => {
+    const mockUser = createUserMock({
+      _id: new Types.ObjectId(userId),
+      email,
+    });
+
+    jest
+      .spyOn(usersService, 'paraseEncryptedParams')
+      .mockReturnValue({ userId, email });
+    jest.spyOn(usersService, 'findById').mockResolvedValue(mockUser);
+
+    const result = await controller.register(encryptedData);
+
+    expect(result).toEqual({ url: `/leads/createLead?email=${email}` });
+  });
+
+  it('should handle invalid links', async () => {
+    jest
+      .spyOn(usersService, 'paraseEncryptedParams')
+      .mockImplementation(() => {
+        throw new Error('Decryption failed');
+      });
+
+    await expect(controller.register(encryptedData)).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});
+
+describe('User Invite Link', () => {
+  const encryptedData = 'encryptedInviteString';
+  const userId = new Types.ObjectId().toString();
+  const email = 'invite@example.com';
+
+  it('should redirect to create lead page when user exists', async () => {
+    const mockUser = createUserMock({
+      _id: new Types.ObjectId(userId),
+      email,
+    });
+
+    jest
+      .spyOn(usersService, 'paraseEncryptedParams')
+      .mockReturnValue({ userId, email });
+    jest.spyOn(usersService, 'findById').mockResolvedValue(mockUser);
+
+    const result = await controller.register(encryptedData);
+
+    expect(result).toEqual({ url: `/leads/createLead?email=${email}` });
+  });
+
+  it('should redirect to new user form when userId is missing', async () => {
+    jest
+      .spyOn(usersService, 'paraseEncryptedParams')
+      .mockReturnValue({ userId: '', email });
+
+    const result = await controller.register(encryptedData);
+
+    expect(result).toEqual({
+      url: `/leads/new-user-form?email=${encodeURIComponent(email)}`,
+    });
+  });
+});
 });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -40,7 +40,7 @@ import { UsersService } from './users.service';
 @ApiTags('users')
 @Controller('users')
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(private readonly usersService: UsersService) { }
 
   @ApiBearerAuth()
   @UseGuards(JwtUsersGuard)

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -11,7 +11,7 @@ import { ConfigService } from '@nestjs/config';
 import { randomBytes } from 'crypto';
 import { format } from 'date-fns';
 import { Model, Types } from 'mongoose';
-import {} from 'src/shared/configs';
+import { } from 'src/shared/configs';
 import { CreateUserDto } from 'src/shared/dtos/create-user.dto';
 import {
   ApiReq,
@@ -61,7 +61,7 @@ export class UsersService {
     @Inject(ContactInfo.name)
     private readonly contactInfoModel: Model<ContactInfo>,
     private readonly configService: ConfigService,
-  ) {}
+  ) { }
 
   sendEmailVerificationToken(req: any, userId: string) {
     (this.userModel as any).sendEmailVerificationToken(req, userId);
@@ -653,9 +653,14 @@ export class UsersService {
   }
 
   // reference routing a new user
-  async createUser(userData: CreateUserDto) {
-    return (this.userModel as any).signUp(userData);
+  async createUser(req: ApiReq, userData: CreateUserDto) {
+    return (this.userModel as any).signUp(req, userData, false, {
+      BasicInfoModel: this.basicInfoModel,
+      ProfessionalInfoModel: this.professionalInfoModel,
+      ContactInfoModel: this.contactInfoModel,
+    });
   }
+
   async requestVerification(req: ApiReq, userId: string) {
     const user = await this.userModel.findById(userId);
     if (!user) {
@@ -663,7 +668,7 @@ export class UsersService {
     }
 
     const now = new Date();
-    
+
     if (
       user.nextVerificationRequestDate &&
       now < user.nextVerificationRequestDate
@@ -673,11 +678,10 @@ export class UsersService {
         `You already submitted a request. Try again after ${retryDate}`,
       );
     }
-    
+
     if (user.applicationStatus === ApplicationStatus.APPROVED) {
       throw new BadRequestException('You are already verified.');
     }
-
 
     // Update user state
     user.applicationStatus = ApplicationStatus.PENDING;
@@ -698,13 +702,12 @@ export class UsersService {
         nextTryDate: format(user.nextVerificationRequestDate, 'PPPP'),
       },
     });
-  
+
     return {
       message: 'Verification request sent.',
       nextAllowedRequest: user.nextVerificationRequestDate,
     };
   }
-  
 
   // service for testing mail
   pingMail() {


### PR DESCRIPTION
# PR: Clean up default NestJS branding from README

## Description
This PR removes generic NestJS starter boilerplate sections from the project's root `README.md` to make it clean, professional, and specific to the Inventor platform.

## Key Changes
* **Removed Default Branding**: Removed the NestJS logo, starter project description, and generic NPM status/coverage badges.
* **Streamlined Footer**: Removed Kamil Myśliwiec's author/social links and generic MIT license support declarations.
* **Unified Documentation**: Kept all project-specific installation, environment variables configuration, local execution, testing, and Swagger API usage guides intact.